### PR TITLE
Buildpack Registry

### DIFF
--- a/.github/workflows/create-package.yml
+++ b/.github/workflows/create-package.yml
@@ -147,3 +147,9 @@ jobs:
               env:
                 DIGEST: ${{ steps.package.outputs.digest }}
                 GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            - uses: docker://ghcr.io/buildpacks/actions/registry:main
+              with:
+                address: gcr.io/paketo-buildpacks/spring-boot-native-image@${{ steps.package.outputs.digest }}
+                id: paketo-buildpacks/spring-boot-native-image
+                token: ${{ secrets.JAVA_BUILDPACK_REGISTRY_TOKEN }}
+                version: ${{ steps.version.outputs.version }}


### PR DESCRIPTION
This change updates the create-package workflow to register a release with the buildpack registry index after it has been created.
