### PR TITLE
Rename to paketo-buildpacks/native-image-build and remove boot-specific logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,33 +1,28 @@
 # `gcr.io/paketo-buildpacks/spring-boot-native-image`
-The Paketo Spring Boot Native Image Buildpack is a Cloud Native Buildpack that creates native images from Spring Boot applications.
+The Paketo Native Image Buildpack is a Cloud Native Buildpack that uses the [GraalVM Native Image builder][native-image] (`native-image`) to compile a standalone executable from an executable JAR.
+
+Most users should not use this component buildpack directly and should instead use the [Paketo Java Native Image][bp/java-native-image], which provides the full set of buildpacks required to build a native image application.
 
 ## Behavior
-This buildpack will participate all the following conditions are met
+This buildpack will participate if one the following conditions are met:
 
-* `$BP_BOOT_NATIVE_IMAGE` is set
+* `$BP_NATIVE_IMAGE` is set.
+*  An upstream buildpack requests `native-image-application` in the build plan.
 
 The buildpack will do the following:
 
-* Creates a GraalVM native image and removes existing bytecode.
-
-This buildpack requires that [Spring Native](https://github.com/spring-projects-experimental/spring-native) is included as an application dependency.
+* Requests that the Native Image builder be installed by requiring `native-image-builder` in the build plan.
+* Uses `native-image` a to build a GraalVM native image and removes existing bytecode.
 
 ## Configuration
 | Environment Variable | Description
 | -------------------- | -----------
-| `$BP_BOOT_NATIVE_IMAGE` | Whether to build a native image from the application.  Defaults to false.
-| `$BP_BOOT_NATIVE_IMAGE_BUILD_ARGUMENTS` | Configure the arguments to pass to native image build
-
-## Bindings
-The buildpack optionally accepts the following bindings:
-
-### Type: `dependency-mapping`
-|Key                   | Value   | Description
-|----------------------|---------|------------
-|`<dependency-digest>` | `<uri>` | If needed, the buildpack will fetch the dependency with digest `<dependency-digest>` from `<uri>`
+| `$BP_NATIVE_IMAGE` | Whether to build a native image from the application.  Defaults to false.
+| `$BP_NATIVE_IMAGE_BUILD_ARGUMENTS` | Arguments to pass to the `native-image` command.
 
 ## License
 This buildpack is released under version 2.0 of the [Apache License][a].
 
 [a]: http://www.apache.org/licenses/LICENSE-2.0
-[s]: https://github.com/spring-projects-experimental/spring-native
+[native-image]: https://www.graalvm.org/reference-manual/native-image/
+[bp/java-native-image]: https://github.com/paketo-buildpacks/java-native-image

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -15,8 +15,8 @@
 api = "0.5"
 
 [buildpack]
-id       = "paketo-buildpacks/spring-boot-native-image"
-name     = "Paketo Spring Boot Native Image Buildpack"
+id       = "paketo-buildpacks/native-image"
+name     = "Paketo Native Image Buildpack"
 version  = "{{.version}}"
 homepage = "https://github.com/paketo-buildpacks/spring-boot-native-image"
 
@@ -30,13 +30,13 @@ id = "io.paketo.stacks.tiny"
 id = "org.cloudfoundry.stacks.cflinuxfs3"
 
 [[metadata.configurations]]
-name        = "BP_BOOT_NATIVE_IMAGE"
-description = "the build to create a native image (requires GraalVM)"
+name        = "BP_NATIVE_IMAGE"
+description = "enable native image build"
 build       = true
 
 [[metadata.configurations]]
-name        = "BP_BOOT_NATIVE_IMAGE_BUILD_ARGUMENTS"
-description = "the arguments to pass to the native-image command"
+name        = "BP_NATIVE_IMAGE_BUILD_ARGUMENTS"
+description = "arguments to pass to the native-image command"
 build       = true
 
 [metadata]

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.15
 
 require (
 	github.com/buildpacks/libcnb v1.19.0
+	github.com/heroku/color v0.0.6
 	github.com/magiconair/properties v1.8.4
 	github.com/mattn/go-shellwords v1.0.11
 	github.com/onsi/gomega v1.11.0

--- a/native/detect_test.go
+++ b/native/detect_test.go
@@ -35,8 +35,102 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 		detect native.Detect
 	)
 
-	it("fails without BP_BOOT_NATIVE_IMAGE", func() {
-		Expect(detect.Detect(ctx)).To(Equal(libcnb.DetectResult{Pass: false}))
+	context("neither BP_NATIVE_IMAGE nor BP_BOOT_NATIVE_IMAGE are set", func() {
+		it("provides but does not requires native-image-application", func() {
+			Expect(detect.Detect(ctx)).To(Equal(libcnb.DetectResult{
+				Pass: true,
+				Plans: []libcnb.BuildPlan{
+					{
+						Provides: []libcnb.BuildPlanProvide{
+							{Name: "native-image-application"},
+						},
+						Requires: []libcnb.BuildPlanRequire{
+							{
+								Name: "native-image-builder",
+							},
+							{
+								Name:     "jvm-application",
+								Metadata: map[string]interface{}{"native-image": true},
+							},
+							{
+								Name:     "spring-boot",
+								Metadata: map[string]interface{}{"native-image": true},
+							},
+						},
+					},
+					{
+						Provides: []libcnb.BuildPlanProvide{
+							{Name: "native-image-application"},
+						},
+						Requires: []libcnb.BuildPlanRequire{
+							{
+								Name: "native-image-builder",
+							},
+							{
+								Name:     "jvm-application",
+								Metadata: map[string]interface{}{"native-image": true},
+							},
+						},
+					},
+				},
+			}))
+		})
+	})
+
+	context("$BP_NATIVE_IMAGE", func() {
+		it.Before(func() {
+			Expect(os.Setenv("BP_NATIVE_IMAGE", "true")).To(Succeed())
+		})
+
+		it.After(func() {
+			Expect(os.Unsetenv("BP_NATIVE_IMAGE")).To(Succeed())
+		})
+
+		it("provides and requires native-image-application", func() {
+			Expect(detect.Detect(ctx)).To(Equal(libcnb.DetectResult{
+				Pass: true,
+				Plans: []libcnb.BuildPlan{
+					{
+						Provides: []libcnb.BuildPlanProvide{
+							{Name: "native-image-application"},
+						},
+						Requires: []libcnb.BuildPlanRequire{
+							{
+								Name: "native-image-builder",
+							},
+							{
+								Name:     "jvm-application",
+								Metadata: map[string]interface{}{"native-image": true},
+							},
+							{
+								Name:     "spring-boot",
+								Metadata: map[string]interface{}{"native-image": true},
+							},
+							{
+								Name: "native-image-application",
+							},
+						},
+					},
+					{
+						Provides: []libcnb.BuildPlanProvide{
+							{Name: "native-image-application"},
+						},
+						Requires: []libcnb.BuildPlanRequire{
+							{
+								Name: "native-image-builder",
+							},
+							{
+								Name:     "jvm-application",
+								Metadata: map[string]interface{}{"native-image": true},
+							},
+							{
+								Name: "native-image-application",
+							},
+						},
+					},
+				},
+			}))
+		})
 	})
 
 	context("$BP_BOOT_NATIVE_IMAGE", func() {
@@ -48,18 +142,17 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 			Expect(os.Unsetenv("BP_BOOT_NATIVE_IMAGE")).To(Succeed())
 		})
 
-		it("passes with BP_BOOT_NATIVE_IMAGE", func() {
+		it("provides and requires native-image-application", func() {
 			Expect(detect.Detect(ctx)).To(Equal(libcnb.DetectResult{
 				Pass: true,
 				Plans: []libcnb.BuildPlan{
 					{
 						Provides: []libcnb.BuildPlanProvide{
-							{Name: "spring-boot-native-image"},
+							{Name: "native-image-application"},
 						},
 						Requires: []libcnb.BuildPlanRequire{
 							{
-								Name:     "jdk",
-								Metadata: map[string]interface{}{"native-image": true},
+								Name: "native-image-builder",
 							},
 							{
 								Name:     "jvm-application",
@@ -69,12 +162,30 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 								Name:     "spring-boot",
 								Metadata: map[string]interface{}{"native-image": true},
 							},
-							{Name: "spring-boot-native-image"},
+							{
+								Name: "native-image-application",
+							},
+						},
+					},
+					{
+						Provides: []libcnb.BuildPlanProvide{
+							{Name: "native-image-application"},
+						},
+						Requires: []libcnb.BuildPlanRequire{
+							{
+								Name: "native-image-builder",
+							},
+							{
+								Name:     "jvm-application",
+								Metadata: map[string]interface{}{"native-image": true},
+							},
+							{
+								Name: "native-image-application",
+							},
 						},
 					},
 				},
 			}))
 		})
 	})
-
 }


### PR DESCRIPTION
Removes Boot specific logic from the buildpack.
* Renames buildpack ID from `paketo-buildpack/spring-boot-native-image` to `paketo-buildpacks/native-image-build`
* Deprecates `BP_BOOT_NATIVE_IMAGE_*` config values in favor of `BP_NATIVE_*`
* Removes check for `spring-native` or `spring-graalvm-native` dependency
* Relies on upstream buildpacks to properly set `CLASSPATH` for boot JARs (see https://github.com/paketo-buildpacks/spring-boot/pull/68)

Other changes:
* Requests `native-image` tool from `paketo-buildpacks/graalvm` using `native-image-builder` plan entry (see https://github.com/paketo-buildpacks/graalvm/pull/61)
* Removes bindings section from the README. This buildpack does not install any dependencies and therefore does not respect bindings of type `depencency-mapping`.